### PR TITLE
[Init] 글로벌 스타일 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>스카이스캐너</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider } from 'styled-components';
+import styled, { ThemeProvider } from 'styled-components';
 
 import Router from './components/common/Router';
 import GlobalStyle from './styles/globalStyle';
@@ -8,9 +8,20 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <Router />
+      <Container>
+        <Router />
+      </Container>
     </ThemeProvider>
   );
 }
 
 export default App;
+
+const Container = styled.div`
+  width: 1046px;
+
+  @media (width <=1046px) {
+    position: absolute;
+    left: 0;
+  }
+`;

--- a/src/components/main/MainTest.tsx
+++ b/src/components/main/MainTest.tsx
@@ -14,7 +14,7 @@ const MainTest = () => {
 export default MainTest;
 
 const MainTestWrapper = styled.main`
-  background-color: ${({ theme }) => theme.colors.skscan_primary};
+  background-color: ${({ theme }) => theme.colors.skscanPrimary};
   height: 100vh;
 `;
 
@@ -29,6 +29,6 @@ const Title = styled.h1`
   top: 15rem;
   justify-content: center;
   width: 100%;
-  color: ${({ theme }) => theme.colors.skscan_primary};
+  color: ${({ theme }) => theme.colors.skscanPrimary};
   font-size: 10rem;
 `;

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -4,8 +4,6 @@ import reset from 'styled-reset';
 const GlobalStyle = styled.createGlobalStyle`
   ${reset}
 
-  @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
-
   * {
     box-sizing: border-box;
   }

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -34,10 +34,8 @@ const GlobalStyle = styled.createGlobalStyle`
 
   body {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 0 auto;
-    width: 1046px;
+    justify-content: center;
+    width: 100%;
   }
 
   a {


### PR DESCRIPTION
## 🔥 Related Issues

- close #10 

## 💙 작업 내용
- [x] 반응형 너비 수정
- [x] import warning 수정

## ✅ PR Point

>우리가 회의한 내용이랑 살짜악? 다르게 구현했습니다. (구현하다 보니까 회의 내용이 정확히 기억 안 나기도 했고 웹팟장의 의견에 감화되어서,,, 그걸 살짝 반영한 다음에 저희 페이지에 맞게 수정했습니다!!)
- 일단 body 태그에 `width: 100%`를 박고 `justify-content: center`를 주었습니다. 그래서 양옆 여백이 동일하게 유지되도록 했습니다.
- `App.tsx`에서 콘텐츠를 감싸는 div 태그를 만들어줘서 1046px로 너비로 박았습니다. 이렇게 한 이유는!! 콘텐츠는 이 Container 박스 안에서 자유롭게 다루고 body 태그와 Container의 너비 차이만큼 여백이 자동적으로 생기게 해주고 싶었기 때문입니다. **요 부분은 피드백 대환영입니다.**
- 그런데 위와 같은 방법을 사용하면 가운데 정렬 된 `<div id="root">` 태그에 의해 `Container` 안에서 넘치는 콘텐츠 (왼쪽 부분)을 스크롤해서 볼 수 없다는 문제가 생겼기에 미디어 쿼리를 사용해서 `width<=1046`일 때만 `position:absolute; left:0`을 주어서 가려지는 부분까지 보일 수 있게 했습니다.

## 📚 Reference
웹팟짱 김터현💛
