### PR TITLE
[init] 컬러코드 수정 및 추가, 그림자 effects 추가

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -2,7 +2,9 @@ import { DefaultTheme } from 'styled-components';
 
 const colors = {
   skscanPrimary: '#05203C',
-  skscanSecondary: '#0062e3',
+  skscanPrimary2: '#003B88',
+  skscanSecondary: '#0062E3',
+  skscanSecondary2: '#D3E6FF',
   skscanBk: '#161616',
   skscanWt: '#FFFFFF',
   skscanRed: '#FF5B5B',
@@ -14,13 +16,13 @@ const colors = {
   skscanGrey100: '#EEF1F2',
   skscanGrey150: '#E6E7EB',
   skscanGrey200: '#D5D7E0',
-  skscanGrey300: '#B9BCC8',
-  skscanGrey400: '#9699A6',
-  skscanGrey500: '#7E8087',
-  skscanGrey600: '#636469',
-  skscanGrey700: '#555859',
-  skscanGrey800: '#48494A',
-  skscanGrey900: '#383939',
+  skscanGrey300: '#BFC2CE',
+  skscanGrey400: '#9DA1AD',
+  skscanGrey500: '#878c9B',
+  skscanGrey600: '#727682',
+  skscanGrey700: '#5C5F6A',
+  skscanGrey800: '#454851',
+  skscanGrey900: '#2A2B30',
 };
 
 export type ColorsTypes = typeof colors;
@@ -38,6 +40,20 @@ const FONT = ({ family, weight, size }: Font): string => {
     font-size:${size}rem;
     `;
 };
+
+const effects = {
+  boxDrop: `
+  box-shadow: 0 0.4rem 2.5rem 0 rgba(0, 0, 0, 0.10);
+  `,
+  boxDrop2: `
+  box-shadow: 0 0.8rem 2.5rem 0 rgba(0, 0, 0, 0.10);
+  `,
+  boxDrop3: `
+  box-shadow: 0 0.4rem 1.5rem 0 rgba(0, 0, 0, 0.10);
+  `,
+};
+
+export type EffectsTypes = typeof effects;
 
 const fonts = {
   heading01: FONT({
@@ -174,4 +190,5 @@ export type FontsTypes = typeof fonts;
 export const theme: DefaultTheme = {
   colors,
   fonts,
+  effects,
 };


### PR DESCRIPTION
## 🔥 Related Issues

- close #16 

## 💙 작업 내용

- [x] theme color에 primary2, secondary2 색상 추가
- [x] theme effects에 그림자 추가

## ✅ PR Point

<!-- 무슨 이유로 어떻게 코드를 변경했는지 -->
<!-- 어떤 위험이나 우려가 발견되었는지(팀원이 알아야 할 것) -->
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 -->
그림자도 다른 것과 마찬가지로 이렇게 사용하면 됩니다.
```typescript
const BoxDrop = styled.div`
  ${({ theme }) => theme.effects.boxDrop}
```

## 👀 스크린샷 / GIF / 링크
아예 제대로 싹다 확인해부렀습니다;;;
<img width="1552" alt="스크린샷 2023-11-24 오후 5 38 43" src="https://github.com/DO-SOPT-CDS-TEAM-WEB7/Client/assets/55528304/fcf93a14-bd53-48f6-9539-3c94d861a839">

